### PR TITLE
Feature/update editorconfig2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -60,7 +60,7 @@ dotnet_naming_rule.public_members_should_be_pascal_case.symbols  = public_member
 dotnet_naming_rule.public_members_should_be_pascal_case.style    = pascal_case_style
 dotnet_naming_symbols.public_members.applicable_kinds = field, property, method
 dotnet_naming_symbols.public_members.applicable_accessibilities = public
-dotnet_naming_style.pascal_case_underscore_style.capitalization = pascall_case
+dotnet_naming_style.pascal_case_underscore_style.capitalization = pascal_case
 
 # ReSharper(JetBrains Rider) name rule
 dotnet_naming_rule.unity_serialized_field_rule.import_to_resharper = False
@@ -321,4 +321,5 @@ csharp_place_field_attribute_on_same_line = false
 
 [*.{csproj,vbproj,proj,nativeproj,locproj}]
 charset = utf-8
+
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -62,6 +62,9 @@ dotnet_naming_symbols.public_members.applicable_kinds = field, property, method
 dotnet_naming_symbols.public_members.applicable_accessibilities = public
 dotnet_naming_style.pascal_case_underscore_style.capitalization = pascall_case
 
+# ReSharper(JetBrains Rider) name rule
+dotnet_naming_rule.unity_serialized_field_rule.import_to_resharper = False
+
 #### .NET Coding Conventions ####
 # IDE0003: this または Me の修飾を削除する.
 dotnet_style_qualification_for_field = false:suggestion
@@ -318,3 +321,4 @@ csharp_place_field_attribute_on_same_line = false
 
 [*.{csproj,vbproj,proj,nativeproj,locproj}]
 charset = utf-8
+


### PR DESCRIPTION
This pull request makes a minor update to the `.editorconfig` file, specifically adding a ReSharper (JetBrains Rider) naming rule configuration. This change ensures that the Unity serialized field naming rule is not imported into ReSharper, which can help maintain consistent naming conventions across different development tools.

Configuration changes:

* Added `dotnet_naming_rule.unity_serialized_field_rule.import_to_resharper = False` to prevent importing the Unity serialized field naming rule into ReSharper.