### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -8,6 +8,12 @@ on:
     - main
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  actions: read
+  checks: write
+  pull-requests: write
+
 jobs:
   test:
       runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AndanteTribe/LocalPrefs/security/code-scanning/6](https://github.com/AndanteTribe/LocalPrefs/security/code-scanning/6)

Add an explicit `permissions` block at the workflow root (best here since there is a single job and no job-specific override needed).  
Use least privilege required for current steps:

- `contents: read` for `actions/checkout`.
- `actions: read` is safe/explicit for action metadata access.
- `checks: write` to allow test tooling to publish check results when needed (commonly required by test runners using `GITHUB_TOKEN`).
- `pull-requests: write` to allow PR comment/status integrations some test runners perform.

This keeps functionality intact while removing reliance on repository/org defaults.  
Edit only `.github/workflows/unity-test.yml`, inserting `permissions:` between `workflow_dispatch` and `jobs`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
