### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unity-meta-file-check.yml
+++ b/.github/workflows/unity-meta-file-check.yml
@@ -12,6 +12,9 @@ on:
       - src/LocalPrefs.Unity/Packages/**
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   meta-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AndanteTribe/LocalPrefs/security/code-scanning/4](https://github.com/AndanteTribe/LocalPrefs/security/code-scanning/4)

Add an explicit `permissions` block to the workflow file so `GITHUB_TOKEN` is constrained to the minimum required scope.

Best fix here: set workflow-level permissions to `contents: read` near the top-level keys (after `on:` block and before `jobs:`). This applies to all jobs in the workflow unless overridden and preserves current functionality, since this workflow only checks out code and runs a validation action.

File to edit:
- `.github/workflows/unity-meta-file-check.yml`

Change details:
- Insert:
  - `permissions:`
  - `  contents: read`
- No imports, methods, or extra definitions are needed (YAML workflow file).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
