### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AndanteTribe/LocalPrefs/security/code-scanning/3](https://github.com/AndanteTribe/LocalPrefs/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root (best for this single-job workflow) to enforce least privilege while preserving current behavior.

For this workflow, required scopes are:
- `contents: write` (needed for branch push via `git push`)
- `pull-requests: write` (needed for `gh pr create`)

Update `.github/workflows/release.yml` by inserting the `permissions` section after the `concurrency` block and before `jobs`. No imports/dependencies/methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
