### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,6 +1,8 @@
 name: Publish Core to Nuget
 on:
   workflow_dispatch: {}
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/AndanteTribe/LocalPrefs/security/code-scanning/2](https://github.com/AndanteTribe/LocalPrefs/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/publish-nuget.yml` at the workflow root so it applies to all jobs. For this workflow, the minimal required permission is `contents: read` (needed by `actions/checkout`). No additional write scopes are required because publishing uses `secrets.NUGET_API_KEY`, not `GITHUB_TOKEN`.

Best single fix without changing functionality:
- Edit `.github/workflows/publish-nuget.yml`
- Insert after the `on:` trigger section (before `concurrency:`):
  ```yaml
  permissions:
    contents: read
  ```
This preserves behavior while enforcing least privilege for `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
