### PR TITLE
perf: buffer WebGL stream writes until flush

### DIFF
--- a/src/LocalPrefs.Unity/Assets/Tests/IDBStreamTest.cs
+++ b/src/LocalPrefs.Unity/Assets/Tests/IDBStreamTest.cs
@@ -1,0 +1,33 @@
+#if UNITY_WEBGL
+#nullable enable
+
+using System;
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace AndanteTribe.IO.Unity.Tests
+{
+    public class IDBStreamTest
+    {
+        [UnityTest]
+        public IEnumerator MultipleWrites_ArePersistedOnDisposeAsync()
+        {
+            yield return new ToCoroutineEnumerator(async () =>
+            {
+                var path = $"idb-stream-buffered-write-{Guid.NewGuid():N}";
+                await using (var stream = new IDBStream(path))
+                {
+                    await stream.WriteAsync(new byte[] { 1, 2 });
+                    await stream.WriteAsync(new byte[] { 3, 4 });
+                }
+
+                var actual = await IDBUtils.ReadAllBytesAsync(path);
+                Assert.That(actual, Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
+                await IDBUtils.DeleteAsync(path);
+            });
+        }
+    }
+}
+
+#endif

--- a/src/LocalPrefs.Unity/Assets/Tests/IDBStreamTest.cs.meta
+++ b/src/LocalPrefs.Unity/Assets/Tests/IDBStreamTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0180a9ea46c44c5099c627d5be475110
+timeCreated: 1784369231

--- a/src/LocalPrefs.Unity/Assets/Tests/LSPrefsTest.cs
+++ b/src/LocalPrefs.Unity/Assets/Tests/LSPrefsTest.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_WEBGL
+#if UNITY_WEBGL
 #nullable enable
 
 using System;
@@ -199,6 +199,26 @@ namespace AndanteTribe.IO.Unity.Tests
             {
                 await LocalPrefsTest.AddAndRemoveMultipleTimes(factory);
             });
+        }
+
+        [Test]
+        public void LSStream_MultipleWrites_ArePersistedOnFlush()
+        {
+            const string path = "ls-stream-buffered-write";
+            try
+            {
+                using var stream = new LSStream(path);
+                stream.Write(new byte[] { 1, 2 }, 0, 2);
+                stream.Write(new byte[] { 3, 4 }, 0, 2);
+
+                Assert.That(LSUtils.ReadAllBytes(path), Is.Empty);
+                stream.Flush();
+                Assert.That(LSUtils.ReadAllBytes(path), Is.EqualTo(new byte[] { 1, 2, 3, 4 }));
+            }
+            finally
+            {
+                LSUtils.Delete(path);
+            }
         }
     }
 }

--- a/src/LocalPrefs.Unity/Packages/jp.andantetribe.localprefs/Runtime/IDBStream.cs
+++ b/src/LocalPrefs.Unity/Packages/jp.andantetribe.localprefs/Runtime/IDBStream.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_WEBGL
+#if UNITY_WEBGL
 #nullable enable
 
 using System;
@@ -11,12 +11,18 @@ namespace AndanteTribe.IO.Unity
     /// <summary>
     /// Represents a stream for IndexedDB operations.
     /// </summary>
-    /// <remarks>No multi-threading support because multi-threading is not allowed in the WebGL environment.</remarks>
+    /// <remarks>
+    /// No multi-threading support because multi-threading is not allowed in the WebGL environment.
+    /// Writes are buffered until <see cref="FlushAsync(CancellationToken)"/> or <see cref="DisposeAsync"/> is called.
+    /// </remarks>
     public class IDBStream : Stream
     {
         private readonly string _path;
         private byte[] _buffer = Array.Empty<byte>();
         private int _written;
+        private int _writeVersion;
+        private bool _isDirty;
+        private bool _isDisposed;
 
         /// <inheritdoc />
         public override bool CanRead => true;
@@ -46,7 +52,59 @@ namespace AndanteTribe.IO.Unity
         /// <inheritdoc />
         public override void Flush()
         {
-            // Flush is typically implemented as an empty method to ensure full compatibility with other Stream types.
+            ThrowIfDisposed();
+            if (_isDirty)
+            {
+                throw new NotSupportedException("Synchronous Flush is not supported in WebGL. Use FlushAsync instead.");
+            }
+        }
+
+        /// <inheritdoc />
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!_isDirty)
+            {
+                return;
+            }
+
+            var flushedVersion = _writeVersion;
+            await IDBUtils.WriteAllBytesAsync(_path, new ReadOnlyMemory<byte>(_buffer, 0, _written), cancellationToken);
+            if (_writeVersion == flushedVersion)
+            {
+                _isDirty = false;
+            }
+        }
+
+        /// <inheritdoc />
+        public override async ValueTask DisposeAsync()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            await FlushAsync(CancellationToken.None);
+            Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !_isDisposed)
+            {
+                if (_isDirty)
+                {
+                    throw new InvalidOperationException("The stream has buffered data. Use DisposeAsync to persist it to IndexedDB.");
+                }
+
+                _buffer = Array.Empty<byte>();
+                _isDisposed = true;
+            }
+
+            base.Dispose(disposing);
         }
 
         /// <inheritdoc />
@@ -91,7 +149,7 @@ namespace AndanteTribe.IO.Unity
         {
             cancellationToken.ThrowIfCancellationRequested();
             WriteBuffer(new ReadOnlySpan<byte>(buffer, offset, count));
-            return IDBUtils.WriteAllBytesAsync(_path, new ReadOnlyMemory<byte>(_buffer, 0, _written), cancellationToken).AsTask();
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc />
@@ -99,18 +157,37 @@ namespace AndanteTribe.IO.Unity
         {
             cancellationToken.ThrowIfCancellationRequested();
             WriteBuffer(buffer.Span);
-            return IDBUtils.WriteAllBytesAsync(_path, new ReadOnlyMemory<byte>(_buffer, 0, _written), cancellationToken);
+            return default;
         }
 
         private void WriteBuffer(in ReadOnlySpan<byte> value)
         {
-            if (_buffer.Length < _written + value.Length)
+            ThrowIfDisposed();
+            if (value.IsEmpty)
             {
-                Array.Resize(ref _buffer, _written + value.Length);
+                return;
+            }
+
+            var requiredLength = checked(_written + value.Length);
+            if (_buffer.Length < requiredLength)
+            {
+                var doubledLength = _buffer.Length > int.MaxValue / 2 ? int.MaxValue : _buffer.Length * 2;
+                var newLength = _buffer.Length == 0 ? requiredLength : Math.Max(requiredLength, doubledLength);
+                Array.Resize(ref _buffer, newLength);
             }
 
             value.CopyTo(_buffer.AsSpan()[_written..]);
             _written += value.Length;
+            _writeVersion++;
+            _isDirty = true;
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(IDBStream));
+            }
         }
     }
 }

--- a/src/LocalPrefs.Unity/Packages/jp.andantetribe.localprefs/Runtime/LSStream.cs
+++ b/src/LocalPrefs.Unity/Packages/jp.andantetribe.localprefs/Runtime/LSStream.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_WEBGL
+#if UNITY_WEBGL
 #nullable enable
 
 using System;
@@ -12,11 +12,14 @@ namespace AndanteTribe.IO.Unity
     /// <summary>
     /// Represents a stream that reads from and writes to Local Storage in WebGL builds.
     /// </summary>
+    /// <remarks>Writes are buffered until <see cref="Flush"/> or <see cref="Dispose()"/> is called.</remarks>
     public class LSStream : Stream
     {
         private readonly string _path;
         private NativeArray<byte> _buffer;
         private int _written;
+        private bool _isDirty;
+        private bool _isDisposed;
 
         /// <inheritdoc />
         public override bool CanRead => true;
@@ -46,9 +49,20 @@ namespace AndanteTribe.IO.Unity
         /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {
-            if (_buffer.IsCreated)
+            if (disposing && !_isDisposed)
             {
-                _buffer.Dispose();
+                try
+                {
+                    Flush();
+                }
+                finally
+                {
+                    if (_buffer.IsCreated)
+                    {
+                        _buffer.Dispose();
+                    }
+                    _isDisposed = true;
+                }
             }
             base.Dispose(disposing);
         }
@@ -56,7 +70,14 @@ namespace AndanteTribe.IO.Unity
         /// <inheritdoc />
         public override void Flush()
         {
-            // Flush is typically implemented as an empty method to ensure full compatibility with other Stream types.
+            ThrowIfDisposed();
+            if (!_isDirty)
+            {
+                return;
+            }
+
+            LSUtils.WriteAllBytes(_path, _buffer.AsSpan()[.._written]);
+            _isDirty = false;
         }
 
         /// <inheritdoc />
@@ -103,7 +124,7 @@ namespace AndanteTribe.IO.Unity
 
         /// <inheritdoc />
         public override void Write(byte[] buffer, int offset, int count) =>
-            LSUtils.WriteAllBytes(_path, WriteBuffer(new ReadOnlySpan<byte>(buffer, offset, count)));
+            WriteBuffer(new ReadOnlySpan<byte>(buffer, offset, count));
 
         /// <inheritdoc />
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -117,22 +138,27 @@ namespace AndanteTribe.IO.Unity
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            LSUtils.WriteAllBytes(_path, WriteBuffer(buffer.Span));
+            WriteBuffer(buffer.Span);
             return default;
         }
 
-        private ReadOnlySpan<byte> WriteBuffer(in ReadOnlySpan<byte> value)
+        private void WriteBuffer(in ReadOnlySpan<byte> value)
         {
-            if (!_buffer.IsCreated && _buffer.Length != 0)
+            ThrowIfDisposed();
+            if (value.IsEmpty)
             {
-                throw new ObjectDisposedException(nameof(LSStream));
+                return;
             }
-            if (_buffer.Length < _written + value.Length)
+
+            var requiredLength = checked(_written + value.Length);
+            if (_buffer.Length < requiredLength)
             {
-                var newBuffer = new NativeArray<byte>(_written + value.Length, Allocator.Persistent);
-                if (_buffer.Length != 0)
+                var doubledLength = _buffer.Length > int.MaxValue / 2 ? int.MaxValue : _buffer.Length * 2;
+                var newLength = _buffer.Length == 0 ? requiredLength : Math.Max(requiredLength, doubledLength);
+                var newBuffer = new NativeArray<byte>(newLength, Allocator.Persistent);
+                if (_written != 0)
                 {
-                    _buffer.CopyTo(newBuffer);
+                    _buffer.AsSpan()[.._written].CopyTo(newBuffer.AsSpan());
                     _buffer.Dispose();
                 }
                 _buffer = newBuffer;
@@ -140,7 +166,15 @@ namespace AndanteTribe.IO.Unity
 
             value.CopyTo(_buffer.AsSpan()[_written..]);
             _written += value.Length;
-            return _buffer.AsSpan()[.._written];
+            _isDirty = true;
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(LSStream));
+            }
         }
     }
 }


### PR DESCRIPTION
## 概要

WebGL の `LSStream` / `IDBStream` で、`Write` のたびに累積データ全体を永続化していた実装を、メモリ上でバッファリングして `Flush` / `Dispose` 時にまとめて永続化する方式へ変更します。公開 API のシグネチャは変更しません。

## 発生していた問題

従来は各 `Write` ごとに、それまで書いた全バイト列を LocalStorage / IndexedDB へ保存していました。N個のチャンクを書き込むと永続化する総量は概ね `1 + 2 + ... + N` となり、累積バッファ全体のコピー、Base64変換と JavaScript bridge、IndexedDB の open / transaction / write が繰り返されます。小さいチャンクを多数書くほど write amplification が大きくなります。

## 修正内容

- 書き込みデータを managed memory に保持
- 容量不足時は指数的に拡張し、毎回の再確保を抑制
- dirty state を導入し、未変更時の不要な永続化を回避
- `LSStream` は `Flush` / `Dispose` で LocalStorage へ保存
- `IDBStream` は `FlushAsync` / `DisposeAsync` で IndexedDB へ保存
- async flush 中に別の write が行われた場合、古い flush が新しい dirty state を消さないよう write version を追跡
- 複数 write が flush / dispose で順序通り永続化される回帰テストを追加
- IndexedDB のテストは他PRに依存しない独立ファイルへ分離

## 同期 Dispose / Flush の扱い

IndexedDB の永続化は非同期処理です。dirty な `IDBStream` に対して同期 `Flush` / `Dispose` を呼ぶと、完了を待てずにデータを失う可能性があります。このPRでは黙って破棄せず例外を送出し、`FlushAsync` または `DisposeAsync` の利用を要求します。LocalStorage は同期 API のため、`LSStream` の同期 `Flush` / `Dispose` で保存できます。

## 影響範囲

- 公開 API のシグネチャ変更なし
- write ごとの永続化から、stream として一般的な flush / dispose 境界での永続化へ変更
- `IDBStream` の利用側は、書き込み後に `FlushAsync` または `DisposeAsync` が必要
- 保存される最終バイト列の形式は変更なし

## 検証

- `dotnet format` を変更 C# ファイルへ実行
- 統合差分で Rider / Unity コンパイル成功
- WebGL Player テスト画面で `All test(s) succeeded` を確認
- LocalStorage: 複数 write を flush / dispose した結果を検証
- IndexedDB: 複数 `WriteAsync` を `DisposeAsync` した結果を再読み込みして検証
