### PR TITLE
chore: update MessagePack to 3.1.8

### DIFF
--- a/src/LocalPrefs.MessagePack/LocalPrefs.MessagePack.csproj
+++ b/src/LocalPrefs.MessagePack/LocalPrefs.MessagePack.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MessagePack" Version="3.1.3" />
+      <PackageReference Include="MessagePack" Version="3.1.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/LocalPrefs.Tests/LocalPrefs.Tests.csproj
+++ b/src/LocalPrefs.Tests/LocalPrefs.Tests.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
-        <PackageReference Include="MessagePack" Version="3.1.3" />
+        <PackageReference Include="MessagePack" Version="3.1.8" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
         <PackageReference Include="NUnit" Version="3.14.0" />
         <PackageReference Include="NUnit.Analyzers" Version="4.4.0"/>

--- a/src/LocalPrefs.Unity/Packages/manifest.json
+++ b/src/LocalPrefs.Unity/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
-    "com.github.messagepack-csharp": "https://github.com/MessagePack-CSharp/MessagePack-CSharp.git?path=src/MessagePack.UnityClient/Assets/Scripts/MessagePack",
+    "com.github.messagepack-csharp": "https://github.com/MessagePack-CSharp/MessagePack-CSharp.git?path=src/MessagePack.UnityClient/Assets/Scripts/MessagePack#v3.1.8",
     "com.unity.ide.rider": "3.0.36",
     "com.unity.test-framework": "1.4.6",
     "com.unity.testtools.codecoverage": "1.2.6",

--- a/src/LocalPrefs.Unity/Packages/nuget-packages/packages.config
+++ b/src/LocalPrefs.Unity/Packages/nuget-packages/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MessagePack" version="3.1.3" manuallyInstalled="true" />
-  <package id="MessagePack.Annotations" version="3.1.3" />
-  <package id="MessagePackAnalyzer" version="3.1.3" />
+  <package id="MessagePack" version="3.1.8" manuallyInstalled="true" />
+  <package id="MessagePack.Annotations" version="3.1.8" />
+  <package id="MessagePackAnalyzer" version="3.1.8" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="9.0.5" />
   <package id="Microsoft.NET.StringTools" version="17.11.4" />
   <package id="System.Buffers" version="4.5.1" />

--- a/src/LocalPrefs.Unity/Packages/packages-lock.json
+++ b/src/LocalPrefs.Unity/Packages/packages-lock.json
@@ -8,11 +8,11 @@
       "hash": "d30cb64a988ac3ecfd31bd9dc96e38422a729e47"
     },
     "com.github.messagepack-csharp": {
-      "version": "https://github.com/MessagePack-CSharp/MessagePack-CSharp.git?path=src/MessagePack.UnityClient/Assets/Scripts/MessagePack",
+      "version": "https://github.com/MessagePack-CSharp/MessagePack-CSharp.git?path=src/MessagePack.UnityClient/Assets/Scripts/MessagePack#v3.1.8",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "e9ba7483fe45b4b1d133d6c3a0bf0529e212522f"
+      "hash": "9f80a327ae139203c1e48fa678f95cf45e878963"
     },
     "com.unity.ext.nunit": {
       "version": "2.0.5",


### PR DESCRIPTION
## 概要

.NET プロジェクトと Unity プロジェクトで使用する MessagePack を 3.1.3 から 3.1.8 へ更新します。機能修正とは独立して採否判断できるよう、依存関係更新だけのPRに分離しています。

## 更新箇所

- `LocalPrefs.MessagePack.csproj`
- `LocalPrefs.Tests.csproj`
- Unity `Packages/manifest.json`
- Unity NuGetForUnity `packages.config`
- Unity `packages-lock.json`

すべて 3.1.8 に揃え、.NET と Unity で異なるバージョンを参照しないようにしています。

## 更新理由

3.1.3 では restore / build 時に MessagePack に対する複数の `NU1902`（moderate）および `NU1903`（high）警告が報告されます。3.1.8 へ更新すると、今回確認された MessagePack の脆弱性警告は解消します。

## 影響範囲

- C# の公開 API / 実装変更なし
- 保存処理のコード変更なし
- package reference と lock 情報のみ更新
- 他の機能修正PRを前提にしない独立ブランチ

## 検証

- `dotnet test src/LocalPrefs.Tests/LocalPrefs.Tests.csproj --configuration Release --framework net9.0`: 77 / 77 passed
- MessagePack の `NU1902` / `NU1903` が解消されることを確認
- `NUnit3TestAdapter` の `NU1701` は既存の別パッケージ警告として残存

## 書式について

このPRの変更対象は `.csproj` / JSON / lock file のみで、C# ソース変更はありません。
